### PR TITLE
修正 size 为文件大小，添加已下载大小

### DIFF
--- a/deluge_peerbanhelperadapter/core.py
+++ b/deluge_peerbanhelperadapter/core.py
@@ -133,7 +133,7 @@ class Core(CorePluginBase):
             torrent.name = deluge_torrent.get_name()
             torrent.info_hash = torrent_id
             torrent.progress = deluge_torrent.get_progress()
-            torrent.completed_size = deluge_torrent.status.total_wanted_done
+            torrent.completed_size = deluge_torrent.status.total_done
             torrent.upload_payload_rate = deluge_torrent.status.upload_payload_rate
             torrent.download_payload_rate = deluge_torrent.status.download_payload_rate
             # LT torrent_info
@@ -209,7 +209,7 @@ class Core(CorePluginBase):
             torrent.name = deluge_torrent.get_name()
             torrent.info_hash = torrent_id
             torrent.progress = deluge_torrent.get_progress()
-            torrent.completed_size = deluge_torrent.status.total_wanted_done
+            torrent.completed_size = deluge_torrent.status.total_done
             # LT torrent_info
             torrent_info = deluge_torrent.handle.torrent_file()
             torrent.priv = torrent_info.priv()

--- a/deluge_peerbanhelperadapter/core.py
+++ b/deluge_peerbanhelperadapter/core.py
@@ -133,7 +133,7 @@ class Core(CorePluginBase):
             torrent.name = deluge_torrent.get_name()
             torrent.info_hash = torrent_id
             torrent.progress = deluge_torrent.get_progress()
-            torrent.completed_size = deluge_torrent.status.total_done
+            torrent.completed_size = deluge_torrent.status.total_wanted_done
             torrent.upload_payload_rate = deluge_torrent.status.upload_payload_rate
             torrent.download_payload_rate = deluge_torrent.status.download_payload_rate
             # LT torrent_info
@@ -209,7 +209,7 @@ class Core(CorePluginBase):
             torrent.name = deluge_torrent.get_name()
             torrent.info_hash = torrent_id
             torrent.progress = deluge_torrent.get_progress()
-            torrent.completed_size = deluge_torrent.status.total_done
+            torrent.completed_size = deluge_torrent.status.total_wanted_done
             # LT torrent_info
             torrent_info = deluge_torrent.handle.torrent_file()
             torrent.priv = torrent_info.priv()

--- a/deluge_peerbanhelperadapter/core.py
+++ b/deluge_peerbanhelperadapter/core.py
@@ -133,12 +133,13 @@ class Core(CorePluginBase):
             torrent.name = deluge_torrent.get_name()
             torrent.info_hash = torrent_id
             torrent.progress = deluge_torrent.get_progress()
-            torrent.size = deluge_torrent.status.total_wanted
+            torrent.completed_size = deluge_torrent.status.total_wanted_done
             torrent.upload_payload_rate = deluge_torrent.status.upload_payload_rate
             torrent.download_payload_rate = deluge_torrent.status.download_payload_rate
             # LT torrent_info
             torrent_info = deluge_torrent.handle.torrent_file()
             torrent.priv = torrent_info.priv()
+            torrent.size = torrent_info.total_size()
             # LT peer_info
             lt_peers = deluge_torrent.handle.get_peer_info()
             peers = []
@@ -208,10 +209,11 @@ class Core(CorePluginBase):
             torrent.name = deluge_torrent.get_name()
             torrent.info_hash = torrent_id
             torrent.progress = deluge_torrent.get_progress()
-            torrent.size = deluge_torrent.status.total_wanted
+            torrent.completed_size = deluge_torrent.status.total_wanted_done
             # LT torrent_info
             torrent_info = deluge_torrent.handle.torrent_file()
             torrent.priv = torrent_info.priv()
+            torrent.size = torrent_info.total_size()
 
             torrents.append(torrent.dist())
 

--- a/deluge_peerbanhelperadapter/core.py
+++ b/deluge_peerbanhelperadapter/core.py
@@ -133,13 +133,19 @@ class Core(CorePluginBase):
             torrent.name = deluge_torrent.get_name()
             torrent.info_hash = torrent_id
             torrent.progress = deluge_torrent.get_progress()
-            torrent.completed_size = deluge_torrent.status.total_wanted_done
             torrent.upload_payload_rate = deluge_torrent.status.upload_payload_rate
             torrent.download_payload_rate = deluge_torrent.status.download_payload_rate
+
             # LT torrent_info
             torrent_info = deluge_torrent.handle.torrent_file()
-            torrent.priv = torrent_info.priv()
             torrent.size = torrent_info.total_size()
+            torrent.priv = torrent_info.priv()
+            piece_length = torrent_info.piece_length()
+
+            # LT torrent_status
+            torrent_status = deluge_torrent.handle.status()
+            torrent.completed_size = torrent_status.num_pieces * piece_length
+
             # LT peer_info
             lt_peers = deluge_torrent.handle.get_peer_info()
             peers = []
@@ -209,11 +215,16 @@ class Core(CorePluginBase):
             torrent.name = deluge_torrent.get_name()
             torrent.info_hash = torrent_id
             torrent.progress = deluge_torrent.get_progress()
-            torrent.completed_size = deluge_torrent.status.total_wanted_done
+
             # LT torrent_info
             torrent_info = deluge_torrent.handle.torrent_file()
-            torrent.priv = torrent_info.priv()
             torrent.size = torrent_info.total_size()
+            torrent.priv = torrent_info.priv()
+            piece_length = torrent_info.piece_length()
+
+            # LT torrent_status
+            torrent_status = deluge_torrent.handle.status()
+            torrent.completed_size = torrent_status.num_pieces * piece_length
 
             torrents.append(torrent.dist())
 

--- a/deluge_peerbanhelperadapter/model/torrent.py
+++ b/deluge_peerbanhelperadapter/model/torrent.py
@@ -80,7 +80,7 @@ class Torrent(BaseModel):
     # 种子大小
     size: int = 0
 
-    # 已下载的大小
+    # 种子实际做种大小
     completed_size: int = 0
 
     # 是否为私有种子

--- a/deluge_peerbanhelperadapter/model/torrent.py
+++ b/deluge_peerbanhelperadapter/model/torrent.py
@@ -80,6 +80,9 @@ class Torrent(BaseModel):
     # 种子大小
     size: int = 0
 
+    # 已下载的大小
+    completed_size: int = 0
+
     # 是否为私有种子
     priv: bool = False
 


### PR DESCRIPTION
作为 PBH-BTN/PeerBanHelper#748 的一部分
关联：PBH-BTN/PeerBanHelper#700
修复：PBH-BTN/PeerBanHelper#746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 引入 `completed_size` 属性，以更好地跟踪下载进度。
  - 更新了处理 torrent 信息的逻辑，确保更准确地表示 torrent 大小。

- **错误修复**
  - 增强了错误处理，确保在解码客户端名称时不会影响数据处理流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->